### PR TITLE
Fixing QR Scan Rotation

### DIFF
--- a/AccessLecture.xcodeproj/project.pbxproj
+++ b/AccessLecture.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2C0F886B1760D8EC0062BD16 /* DrawView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C0F886A1760D8EC0062BD16 /* DrawView.m */; };
 		2CBF301C177B7AB10087C17C /* DrawViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CBF301A177B7AB10087C17C /* DrawViewController.m */; };
 		2CBF301D177B7AB10087C17C /* DrawViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2CBF301B177B7AB10087C17C /* DrawViewController.xib */; };
+		2CF45FDD17971C0400E6C69E /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CF45FDC17971C0400E6C69E /* QuartzCore.framework */; };
 		2CF6BA901784919300A695CC /* AMBezierPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CF6BA8D1784919300A695CC /* AMBezierPath.m */; };
 		2CF6BA911784919300A695CC /* arrow.png in Resources */ = {isa = PBXBuildFile; fileRef = 2CF6BA8E1784919300A695CC /* arrow.png */; };
 		2CF6BA921784919300A695CC /* circle.png in Resources */ = {isa = PBXBuildFile; fileRef = 2CF6BA8F1784919300A695CC /* circle.png */; };
@@ -115,6 +116,7 @@
 		2CBF3019177B7AB10087C17C /* DrawViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DrawViewController.h; sourceTree = "<group>"; };
 		2CBF301A177B7AB10087C17C /* DrawViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DrawViewController.m; sourceTree = "<group>"; };
 		2CBF301B177B7AB10087C17C /* DrawViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DrawViewController.xib; sourceTree = "<group>"; };
+		2CF45FDC17971C0400E6C69E /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		2CF6BA8C1784919300A695CC /* AMBezierPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMBezierPath.h; sourceTree = "<group>"; };
 		2CF6BA8D1784919300A695CC /* AMBezierPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AMBezierPath.m; sourceTree = "<group>"; };
 		2CF6BA8E1784919300A695CC /* arrow.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = arrow.png; sourceTree = "<group>"; };
@@ -251,6 +253,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2CF45FDD17971C0400E6C69E /* QuartzCore.framework in Frameworks */,
 				4C4B8BFC178EF8D900C2F94B /* AVFoundation.framework in Frameworks */,
 				3F0F3B71178DCB8B00163C2A /* CoreText.framework in Frameworks */,
 				3FED960C1370863E00D8D1B8 /* UIKit.framework in Frameworks */,
@@ -519,6 +522,7 @@
 		3FED960A1370863E00D8D1B8 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				2CF45FDC17971C0400E6C69E /* QuartzCore.framework */,
 				4C4B8BFB178EF8D900C2F94B /* AVFoundation.framework */,
 				3F0F3B70178DCB8B00163C2A /* CoreText.framework */,
 				3F6D11D217625F150066A4FA /* libicucore.dylib */,

--- a/AccessLecture/ConnectionViewController.m
+++ b/AccessLecture/ConnectionViewController.m
@@ -9,6 +9,7 @@
 #import "ConnectionViewController.h"
 #import "AccessLectureAppDelegate.h"
 #import "ALNetworkInterface.h"
+#import <QuartzCore/CATransform3D.h>
 
 @interface ConnectionViewController ()
 
@@ -137,6 +138,19 @@
         [cancelButton setTitle:@"Cancel" forState:UIControlStateNormal];
         [_previewView addSubview:cancelButton];
     }];
+}
+
+# pragma mark - Rotation Handling
+
+- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
+{
+    if (_previewView){
+        if (UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)){
+            [_previewView.layer setTransform:CATransform3DMakeRotation(90.0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
+        } else if (UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)){
+            [_previewView.layer setTransform:CATransform3DMakeRotation(0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
+        }
+    }
 }
 
 #pragma mark Connect

--- a/AccessLecture/ConnectionViewController.m
+++ b/AccessLecture/ConnectionViewController.m
@@ -75,7 +75,6 @@
 - (void)didReceiveMemoryWarning
 {
     [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
 }
 
 - (IBAction)checkAddress:(id)sender
@@ -150,16 +149,16 @@
     if (_previewView){
         if ([UIDevice currentDevice].orientation == UIInterfaceOrientationPortrait){
             [_previewView.layer setTransform:CATransform3DMakeRotation(0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
-            [self configureScanViewWithDuration:0 withOrientation:0];
+            [self configureScanViewWithOrientation:0];
         } else if ([UIDevice currentDevice].orientation == UIInterfaceOrientationLandscapeLeft){
             [_previewView.layer setTransform:CATransform3DMakeRotation(90.0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
-            [self configureScanViewWithDuration:0 withOrientation:90];
+            [self configureScanViewWithOrientation:90];
         } else if ([UIDevice currentDevice].orientation == UIInterfaceOrientationPortraitUpsideDown){
             [_previewView.layer setTransform:CATransform3DMakeRotation(180.0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
-            [self configureScanViewWithDuration:0 withOrientation:180];
+            [self configureScanViewWithOrientation:180];
         }else if ([UIDevice currentDevice].orientation == UIInterfaceOrientationLandscapeRight){
             [_previewView.layer setTransform:CATransform3DMakeRotation(270.0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
-            [self configureScanViewWithDuration:0 withOrientation:270];
+            [self configureScanViewWithOrientation:270];
         }
     }
 }
@@ -167,7 +166,7 @@
 /**
  * Resets scan view to fill the view. Used for handling rotation.
  */
-- (void)configureScanViewWithDuration:(NSTimeInterval)seconds withOrientation:(int)orientation
+- (void)configureScanViewWithOrientation:(int)orientation
 {
     [_previewView setFrame:self.view.frame];
     [preview setVideoGravity:AVLayerVideoGravityResizeAspectFill];

--- a/AccessLecture/ConnectionViewController.m
+++ b/AccessLecture/ConnectionViewController.m
@@ -149,12 +149,9 @@
     if (_previewView){
         if (UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)){
             [_previewView.layer setTransform:CATransform3DMakeRotation(90.0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
-//            [_previewView setTransform:CGAffineTransformMakeRotation(90 * M_PI / 180)];
             [self configureScanViewWithDuration:0 withLandscape:YES];
-            
         } else if (UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)){
             [_previewView.layer setTransform:CATransform3DMakeRotation(0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
-//            [_previewView setTransform:CGAffineTransformMakeRotation(0 / 180 * M_PI)];
             [self configureScanViewWithDuration:0 withLandscape:NO];
         }
     }
@@ -171,6 +168,14 @@
         [preview setVideoGravity:AVLayerVideoGravityResizeAspectFill];
         [preview setBounds:_previewView.layer.bounds];
         [preview setPosition:CGPointMake(CGRectGetMidX(_previewView.layer.bounds), CGRectGetMidY(_previewView.layer.bounds))];
+        
+        if (isLandscape){
+            [cancelButton setTransform:CGAffineTransformMakeRotation(270 * M_PI / 180)];
+            [cancelButton setFrame:CGRectMake(_previewView.frame.size.width + 25, _previewView.frame.size.height - 620, 50, 100)];
+        } else {
+            [cancelButton setTransform:CGAffineTransformMakeRotation(0 * M_PI / 180)];
+            [cancelButton setFrame:CGRectMake(_previewView.frame.size.width - 100, _previewView.frame.size.height - 50, 100, 50)];
+        }
     }];
 }
 

--- a/AccessLecture/ConnectionViewController.m
+++ b/AccessLecture/ConnectionViewController.m
@@ -162,21 +162,18 @@
  */
 - (void)configureScanViewWithDuration:(NSTimeInterval)seconds withLandscape:(BOOL)isLandscape
 {
-    [UIView animateWithDuration:seconds animations:^{
-        [_previewView setFrame:self.view.frame];
-    } completion:^(BOOL finished) {
-        [preview setVideoGravity:AVLayerVideoGravityResizeAspectFill];
-        [preview setBounds:_previewView.layer.bounds];
-        [preview setPosition:CGPointMake(CGRectGetMidX(_previewView.layer.bounds), CGRectGetMidY(_previewView.layer.bounds))];
-        
-        if (isLandscape){
-            [cancelButton setTransform:CGAffineTransformMakeRotation(270 * M_PI / 180)];
-            [cancelButton setFrame:CGRectMake(_previewView.frame.size.width + 25, _previewView.frame.size.height - 620, 50, 100)];
-        } else {
-            [cancelButton setTransform:CGAffineTransformMakeRotation(0 * M_PI / 180)];
-            [cancelButton setFrame:CGRectMake(_previewView.frame.size.width - 100, _previewView.frame.size.height - 50, 100, 50)];
-        }
-    }];
+    [_previewView setFrame:self.view.frame];
+    [preview setVideoGravity:AVLayerVideoGravityResizeAspectFill];
+    [preview setBounds:_previewView.layer.bounds];
+    [preview setPosition:CGPointMake(CGRectGetMidX(_previewView.layer.bounds), CGRectGetMidY(_previewView.layer.bounds))];
+    
+    if (isLandscape){
+        [cancelButton setTransform:CGAffineTransformMakeRotation(270 * M_PI / 180)];
+        [cancelButton setFrame:CGRectMake(_previewView.frame.size.width + 25, _previewView.frame.size.height - 620, 50, 100)];
+    } else {
+        [cancelButton setTransform:CGAffineTransformMakeRotation(0 * M_PI / 180)];
+        [cancelButton setFrame:CGRectMake(_previewView.frame.size.width - 100, _previewView.frame.size.height - 50, 100, 50)];
+    }
 }
 
 #pragma mark Connect

--- a/AccessLecture/ConnectionViewController.m
+++ b/AccessLecture/ConnectionViewController.m
@@ -146,13 +146,20 @@
 
 - (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
 {
+    //  NOTE: decimal points in the CATransform are necessary.
     if (_previewView){
-        if (UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)){
-            [_previewView.layer setTransform:CATransform3DMakeRotation(90.0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
-            [self configureScanViewWithDuration:0 withLandscape:YES];
-        } else if (UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)){
+        if ([UIDevice currentDevice].orientation == UIInterfaceOrientationPortrait){
             [_previewView.layer setTransform:CATransform3DMakeRotation(0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
-            [self configureScanViewWithDuration:0 withLandscape:NO];
+            [self configureScanViewWithDuration:0 withOrientation:0];
+        } else if ([UIDevice currentDevice].orientation == UIInterfaceOrientationLandscapeLeft){
+            [_previewView.layer setTransform:CATransform3DMakeRotation(90.0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
+            [self configureScanViewWithDuration:0 withOrientation:90];
+        } else if ([UIDevice currentDevice].orientation == UIInterfaceOrientationPortraitUpsideDown){
+            [_previewView.layer setTransform:CATransform3DMakeRotation(180.0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
+            [self configureScanViewWithDuration:0 withOrientation:180];
+        }else if ([UIDevice currentDevice].orientation == UIInterfaceOrientationLandscapeRight){
+            [_previewView.layer setTransform:CATransform3DMakeRotation(270.0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
+            [self configureScanViewWithDuration:0 withOrientation:270];
         }
     }
 }
@@ -160,19 +167,36 @@
 /**
  * Resets scan view to fill the view. Used for handling rotation.
  */
-- (void)configureScanViewWithDuration:(NSTimeInterval)seconds withLandscape:(BOOL)isLandscape
+- (void)configureScanViewWithDuration:(NSTimeInterval)seconds withOrientation:(int)orientation
 {
     [_previewView setFrame:self.view.frame];
     [preview setVideoGravity:AVLayerVideoGravityResizeAspectFill];
     [preview setBounds:_previewView.layer.bounds];
     [preview setPosition:CGPointMake(CGRectGetMidX(_previewView.layer.bounds), CGRectGetMidY(_previewView.layer.bounds))];
     
-    if (isLandscape){
-        [cancelButton setTransform:CGAffineTransformMakeRotation(270 * M_PI / 180)];
-        [cancelButton setFrame:CGRectMake(_previewView.frame.size.width + 25, _previewView.frame.size.height - 620, 50, 100)];
-    } else {
-        [cancelButton setTransform:CGAffineTransformMakeRotation(0 * M_PI / 180)];
-        [cancelButton setFrame:CGRectMake(_previewView.frame.size.width - 100, _previewView.frame.size.height - 50, 100, 50)];
+    switch (orientation) {
+        case 0:
+            [cancelButton setTransform:CGAffineTransformMakeRotation(0 * M_PI / 180)];
+            [cancelButton setFrame:CGRectMake(_previewView.frame.size.width - 100, _previewView.frame.size.height - 50, 100, 50)];
+            break;
+            
+        case 90:
+            [cancelButton setTransform:CGAffineTransformMakeRotation(270 * M_PI / 180)];
+            [cancelButton setFrame:CGRectMake(_previewView.frame.size.width + 25, _previewView.frame.size.height - 620, 50, 100)];
+            break;
+        
+        case 180:
+            [cancelButton setTransform:CGAffineTransformMakeRotation(180 * M_PI / 180)];
+            [cancelButton setFrame:CGRectMake(7, _previewView.frame.size.height - 615, 100, 50)];
+            break;
+        
+        case 270:
+            [cancelButton setTransform:CGAffineTransformMakeRotation(90 * M_PI / 180)];
+            [cancelButton setFrame:CGRectMake(0, _previewView.frame.size.height - 175, 50, 100)];
+            break;
+            
+        default:
+            break;
     }
 }
 

--- a/AccessLecture/ConnectionViewController.m
+++ b/AccessLecture/ConnectionViewController.m
@@ -19,6 +19,8 @@
     ALNetworkInterface *server;
     QRScanner *scanner;
     UITapGestureRecognizer *_tapToScan;
+    AVCaptureVideoPreviewLayer *preview;
+    UIButton *cancelButton;
 }
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
@@ -126,13 +128,13 @@
         [_previewView setFrame:self.view.frame];
     } completion:^(BOOL finished) {
         AVCaptureSession *session  = [scanner session];
-        AVCaptureVideoPreviewLayer *preview = [[AVCaptureVideoPreviewLayer alloc] initWithSession:session];
+        preview = [[AVCaptureVideoPreviewLayer alloc] initWithSession:session];
         [preview setVideoGravity:AVLayerVideoGravityResizeAspectFill];
         [preview setBounds:_previewView.layer.bounds];
         [preview setPosition:CGPointMake(CGRectGetMidX(_previewView.layer.bounds), CGRectGetMidY(_previewView.layer.bounds))];
         [_previewView.layer addSublayer:preview];
         
-        UIButton *cancelButton = [[UIButton alloc] initWithFrame:CGRectMake(_previewView.frame.size.width - 100, _previewView.frame.size.height - 50, 100, 50)];
+        cancelButton = [[UIButton alloc] initWithFrame:CGRectMake(_previewView.frame.size.width - 100, _previewView.frame.size.height - 50, 100, 50)];
         [cancelButton addTarget:self action:@selector(userDidCancel:) forControlEvents:UIControlEventTouchDown];
         [cancelButton setBackgroundColor:[UIColor clearColor]];
         [cancelButton setTitle:@"Cancel" forState:UIControlStateNormal];
@@ -147,10 +149,29 @@
     if (_previewView){
         if (UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)){
             [_previewView.layer setTransform:CATransform3DMakeRotation(90.0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
+//            [_previewView setTransform:CGAffineTransformMakeRotation(90 * M_PI / 180)];
+            [self configureScanViewWithDuration:0 withLandscape:YES];
+            
         } else if (UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)){
             [_previewView.layer setTransform:CATransform3DMakeRotation(0 / 180.0 * M_PI, 0.0, 0.0, 1.0)];
+//            [_previewView setTransform:CGAffineTransformMakeRotation(0 / 180 * M_PI)];
+            [self configureScanViewWithDuration:0 withLandscape:NO];
         }
     }
+}
+
+/**
+ * Resets scan view to fill the view. Used for handling rotation.
+ */
+- (void)configureScanViewWithDuration:(NSTimeInterval)seconds withLandscape:(BOOL)isLandscape
+{
+    [UIView animateWithDuration:seconds animations:^{
+        [_previewView setFrame:self.view.frame];
+    } completion:^(BOOL finished) {
+        [preview setVideoGravity:AVLayerVideoGravityResizeAspectFill];
+        [preview setBounds:_previewView.layer.bounds];
+        [preview setPosition:CGPointMake(CGRectGetMidX(_previewView.layer.bounds), CGRectGetMidY(_previewView.layer.bounds))];
+    }];
 }
 
 #pragma mark Connect


### PR DESCRIPTION
- Using `CATransform3DMakeRotation` for the scan preview layer, since it goes through the GPU.
- Lot of tweaking of cancel button position.
